### PR TITLE
feat(cache): add memory and Redis caching for OMDb details

### DIFF
--- a/MoviePicks.Api/Configuration/HybridCacheOptions.cs
+++ b/MoviePicks.Api/Configuration/HybridCacheOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace MoviePicks.Api.Configuration;
+
+public class HybridCacheOptions
+{
+    private const long OneMegabyteLimitPerCachedItem = 1024 * 1024;
+
+    public int LocalCacheExpirationHours { get; set; } = 1;
+
+    public int DistributedCacheExpirationDays { get; set; } = 30;
+
+    public long MaxPayloadBytes { get; set; } = OneMegabyteLimitPerCachedItem;
+}

--- a/MoviePicks.Api/Controllers/OmdbMoviesController.cs
+++ b/MoviePicks.Api/Controllers/OmdbMoviesController.cs
@@ -11,9 +11,9 @@ using System.ComponentModel.DataAnnotations;
 [ApiController]
 public class OmdbMoviesController : ControllerBase
 {
-    private readonly IOmdbApiMoviesReader omdbApiMoviesReader;
+    private readonly IOmdbMoviesReader omdbApiMoviesReader;
 
-    public OmdbMoviesController(IOmdbApiMoviesReader omdbApiMoviesReader)
+    public OmdbMoviesController(IOmdbMoviesReader omdbApiMoviesReader)
     {
         this.omdbApiMoviesReader = omdbApiMoviesReader;
     }

--- a/MoviePicks.Api/Infrastructure/ThirdPartyApiClients/CachedOmdbApiMoviesReader.cs
+++ b/MoviePicks.Api/Infrastructure/ThirdPartyApiClients/CachedOmdbApiMoviesReader.cs
@@ -1,0 +1,43 @@
+﻿namespace MoviePicks.Api.Infrastructure.ThirdPartyApiClients;
+
+using Microsoft.Extensions.Caching.Hybrid;
+using MoviePicks.Contracts.DTOs;
+using MoviePicks.Contracts.Enums;
+
+public class CachedOmdbApiMoviesReader : IOmdbMoviesReader
+{
+    private readonly IOmdbMoviesReader innerReader;
+    private readonly HybridCache hybridCache;
+
+    public CachedOmdbApiMoviesReader(IOmdbMoviesReader innerReader, HybridCache hybridCache)
+    {
+        this.innerReader = innerReader;
+        this.hybridCache = hybridCache;
+    }
+
+    /// <summary>
+    /// Retrieves OMDB movie details from the cache if available, otherwise fetches from the
+    /// OMDB API and caches the result. Cache key is a compound key built from movie imdbId
+    /// and plotSize since Full and Short plots have different payloads.
+    /// </summary>
+    public async Task<OmdbMovieDetailsDto> GetMovieByImdbId(string imdbId, PlotSize plotSize)
+    {
+        string cacheKey = $"omdb:{imdbId}:{plotSize}";
+
+        return await this.hybridCache.GetOrCreateAsync(
+            cacheKey,
+            async cancel => await this.innerReader.GetMovieByImdbId(imdbId, plotSize),
+            cancellationToken: CancellationToken.None);
+    }
+
+    public Task<List<OmdbMovieShortDetailsDto>> SearchMoviesByTitle(string title)
+    {
+        // Title searches are intentionally not cached because this is currently a
+        // single-user application, and I anticipate that the user will not search
+        // for the same title frequently enough to benefit much from caching.
+        // This is an assumption, not something verified through usage measurements.
+        // Reconsider caching if the user repeats searches frequently or the application
+        // gains many users who search for the same popular movies.
+        return this.innerReader.SearchMoviesByTitle(title);
+    }
+}

--- a/MoviePicks.Api/Infrastructure/ThirdPartyApiClients/IOmdbMoviesReader.cs
+++ b/MoviePicks.Api/Infrastructure/ThirdPartyApiClients/IOmdbMoviesReader.cs
@@ -6,9 +6,12 @@ using MoviePicks.Contracts.Enums;
 /// <summary>
 /// Service to read public information about movies
 /// </summary>
-public interface IOmdbApiMoviesReader
+public interface IOmdbMoviesReader
 {
     Task<List<OmdbMovieShortDetailsDto>> SearchMoviesByTitle(string title);
 
+    /// <summary>
+    /// Retrieves OMDb movie details for the specified IMDb ID and plot size.
+    /// </summary>
     Task<OmdbMovieDetailsDto> GetMovieByImdbId(string imdbId, PlotSize plotSize);
 }

--- a/MoviePicks.Api/Infrastructure/ThirdPartyApiClients/OmdbClientServiceCollectionExtensions.cs
+++ b/MoviePicks.Api/Infrastructure/ThirdPartyApiClients/OmdbClientServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace MoviePicks.Api.Infrastructure.ThirdPartyApiClients;
 
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Options;
 using MoviePicks.Api.Configuration;
 
@@ -30,9 +31,13 @@ public static class OmdbClientServiceCollectionExtensions
                 "Invalid configuration: Omdb:BaseUrl must be a valid absolute HTTP/HTTPS URI. Check appsettings.json.")
             .ValidateOnStart();
 
-        // Configure a typed HTTP client for OMDb.
-        // The base address comes from validated configuration above, so no additional checks are needed here.
-        services.AddHttpClient<IOmdbApiMoviesReader, OmdbApiMoviesReader>(
+        // Register OmdbMoviesReader as a typed HTTP client.
+        // - Lifetime: Transient (a new OmdbMoviesReader instance per DI request).
+        // - The underlying HttpMessageHandler and its TCP connection pool are managed
+        //   separately by IHttpClientFactory, so Transient here does not cause socket exhaustion.
+        // - Registered by concrete type (not by IOmdbMoviesReader) so that the decorator
+        //   CachedOmdbApiMoviesReader below can resolve it directly without creating a circular dependency.
+        services.AddHttpClient<OmdbMoviesReader>(
             (serviceProvider, client) =>
             {
                 var options = serviceProvider
@@ -40,6 +45,18 @@ public static class OmdbClientServiceCollectionExtensions
                     .Value;
                 client.BaseAddress = new Uri(options.BaseUrl);
             });
+
+        // Register the caching decorator as the implementation of IOmdbMoviesReader.
+        // - Lifetime: Scoped (one instance per HTTP request).
+        // - Decorator pattern: CachedOmdbApiMoviesReader wraps OmdbMoviesReader and
+        //   adds HybridCache (L1 in-memory + L2 Redis) transparently. All consumers
+        //   that inject IOmdbMoviesReader receive the cached version automatically.
+        // - HybridCache is registered as a singleton by ConfigureServices and shared
+        //   across requests, so these scoped readers use the same L1 in-memory cache.
+        services.AddScoped<IOmdbMoviesReader>(sp =>
+            new CachedOmdbApiMoviesReader(
+                innerReader: sp.GetRequiredService<OmdbMoviesReader>(),
+                hybridCache: sp.GetRequiredService<HybridCache>()));
 
         return services;
     }

--- a/MoviePicks.Api/Infrastructure/ThirdPartyApiClients/OmdbMoviesReader.cs
+++ b/MoviePicks.Api/Infrastructure/ThirdPartyApiClients/OmdbMoviesReader.cs
@@ -4,12 +4,12 @@ using MoviePicks.Api.Models;
 using MoviePicks.Contracts.DTOs;
 using MoviePicks.Contracts.Enums;
 
-public class OmdbApiMoviesReader : IOmdbApiMoviesReader
+public class OmdbMoviesReader : IOmdbMoviesReader
 {
     private readonly HttpClient httpClient;
     private readonly string apiKey;
 
-    public OmdbApiMoviesReader(HttpClient httpClient, IConfiguration configuration)
+    public OmdbMoviesReader(HttpClient httpClient, IConfiguration configuration)
     {
         this.httpClient = httpClient;
         this.apiKey = configuration[ConfigurationManagerKeys.OpenMovieDatabaseApiKey] ??
@@ -32,6 +32,12 @@ public class OmdbApiMoviesReader : IOmdbApiMoviesReader
             throw new InvalidOperationException("The JSON response is empty or invalid.");
         }
 
+        // OMDb can report failure in the JSON body even when the HTTP status is 200.
+        if (!IsSuccessfulOmdbResponse(response.Response))
+        {
+            throw new InvalidOperationException("OMDb did not return successful movie details.");
+        }
+
         return response;
     }
 
@@ -41,7 +47,8 @@ public class OmdbApiMoviesReader : IOmdbApiMoviesReader
 
         OmdbMovieSearchResult? result = await this.httpClient.GetFromJsonAsync<OmdbMovieSearchResult>(url);
 
-        if (result?.search != null && result.Response?.Equals("True") == true)
+        // Return results only when OMDb reports success and provides a non-null search collection.
+        if (result?.search != null && IsSuccessfulOmdbResponse(result.Response))
         {
             return result.search.ToList();
         }
@@ -53,6 +60,14 @@ public class OmdbApiMoviesReader : IOmdbApiMoviesReader
             // TODO: If result is null, then log something. Or perhaps throw InvalidOperationException and allow the caller to handle it and log it.
             return new List<OmdbMovieShortDetailsDto>();
         }
+    }
+
+    private static bool IsSuccessfulOmdbResponse(string? responseStatus)
+    {
+        return string.Equals(
+            responseStatus,
+            "True",
+            StringComparison.OrdinalIgnoreCase);
     }
 
     private static class ConfigurationManagerKeys // TODO Move to it's own file when more keys are needed by other files

--- a/MoviePicks.Api/MoviePicks.Api.csproj
+++ b/MoviePicks.Api/MoviePicks.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -12,19 +12,22 @@
     <None Remove="Controllers\Obsolete\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.14.1" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.3" />
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.4.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MoviePicks.Api/Program.cs
+++ b/MoviePicks.Api/Program.cs
@@ -1,10 +1,13 @@
 using Microsoft.Extensions.Options;
-using MoviePicks.Api.Startup;
 using MoviePicks.Api.Routing;
+using MoviePicks.Api.Startup;
+using MoviePicks.Contracts;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+
+builder.AddRedisDistributedCache(connectionName: BackendInfrastructureConstants.RedisResourceConnectionName);
 
 builder.Services.ConfigureServices(builder.Configuration, builder.Environment);
 

--- a/MoviePicks.Api/Services/BusinessServices/MoviesService.cs
+++ b/MoviePicks.Api/Services/BusinessServices/MoviesService.cs
@@ -1,7 +1,6 @@
 ﻿namespace MoviePicks.Api.Services.BusinessServices;
 
 using Microsoft.EntityFrameworkCore;
-using MoviePicks.Api.Infrastructure.Exceptions;
 using MoviePicks.Api.Infrastructure.Mappers;
 using MoviePicks.Api.Infrastructure.ThirdPartyApiClients;
 using MoviePicks.Api.Models;
@@ -13,9 +12,9 @@ using System.Collections.Generic;
 public class MoviesService : IMoviesService
 {
     private readonly IUnitOfWork unitOfWork;
-    private readonly IOmdbApiMoviesReader omdbMovieReader;
+    private readonly IOmdbMoviesReader omdbMovieReader;
 
-    public MoviesService(DbMovieContext db, IUnitOfWork unitOfWork, IOmdbApiMoviesReader omdbMovieReader)
+    public MoviesService(IUnitOfWork unitOfWork, IOmdbMoviesReader omdbMovieReader)
     {
         this.unitOfWork = unitOfWork;
         this.omdbMovieReader = omdbMovieReader;
@@ -139,17 +138,6 @@ public class MoviesService : IMoviesService
         }
 
         return false;
-
-        try
-        {
-            this.unitOfWork.MovieRepository.Delete(movieId);
-            await this.unitOfWork.SaveAsync();
-        }
-        catch (EntityDeletionException ex)
-        {
-            // Handle or log the exception as needed
-            throw; // Rethrow to be caught by global exception handler
-        }
     }
 
     public async Task<List<MovieViewModel>> GetFilteredMovieViewModels(MovieFilterDto filterDTO)
@@ -180,7 +168,7 @@ public class MoviesService : IMoviesService
     public async Task<MovieViewModel> GetMovieViewModel(int movieId, PlotSize plotSize)
     {
         Movie movie = await Task.Run(() => this.unitOfWork.MovieRepository.GetMovie(movieId));
-        OmdbMovieDetailsDto omdbMovieDetails = await this.omdbMovieReader.GetMovieByImdbId(movie.ImdbId, plotSize);
+        OmdbMovieDetailsDto omdbMovieDetails = await this.GetCachedOmdbMovieDetails(movie.ImdbId, plotSize);
         return new CompositeMovie(movie, omdbMovieDetails).ToMovieViewModel();
     }
 
@@ -197,12 +185,21 @@ public class MoviesService : IMoviesService
 
         foreach (Movie movie in movies)
         {
-            OmdbMovieDetailsDto omdbMovieDetails = await this.omdbMovieReader.GetMovieByImdbId(movie.ImdbId, PlotSize.Short);
+            OmdbMovieDetailsDto omdbMovieDetails = await this.GetCachedOmdbMovieDetails(movie.ImdbId, PlotSize.Short);
 
             compositeMovies.Add(new CompositeMovie(movie, omdbMovieDetails));
         }
 
         return compositeMovies;
+    }
+
+    /// <summary>
+    /// Retrieves OMDB movie details. Caching is handled transparently by the
+    /// cache implementation of IOmdbMoviesReader.
+    /// </summary>
+    private async Task<OmdbMovieDetailsDto> GetCachedOmdbMovieDetails(string imdbId, PlotSize plotSize)
+    {
+        return await this.omdbMovieReader.GetMovieByImdbId(imdbId, plotSize);
     }
 
     private IQueryable<Movie> ApplyRatingFilter(IQueryable<Movie> query, int? rating)
@@ -253,7 +250,7 @@ public class MoviesService : IMoviesService
 
         foreach (var movie in movies)
         {
-            OmdbMovieDetailsDto omdbMovieDetails = await this.omdbMovieReader.GetMovieByImdbId(movie.ImdbId, PlotSize.Short);
+            OmdbMovieDetailsDto omdbMovieDetails = await this.GetCachedOmdbMovieDetails(movie.ImdbId, PlotSize.Short);
             movieViewModels.Add(new CompositeMovie(movie, omdbMovieDetails).ToMovieViewModel());
         }
 

--- a/MoviePicks.Api/Startup/ServiceCollectionExtensions.cs
+++ b/MoviePicks.Api/Startup/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace MoviePicks.Api.Startup;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using MoviePicks.Api.Infrastructure.ThirdPartyApiClients;
 using MoviePicks.Api.Models;
@@ -24,6 +25,24 @@ public static partial class ServiceCollectionExtensions
 
         services.AddEndpointsApiExplorer();
         services.AddOpenApi();
+
+        var cacheSettings = configuration.GetSection("HybridCache").Get<Configuration.HybridCacheOptions>() ?? new ();
+
+#pragma warning disable EXTEXP0018 // Still required as of .NET 10 for the Extensions library
+
+        // AddHybridCache registers HybridCache as a singleton.
+        // Requests handled by this API instance share the same cache service
+        // and L1 in-memory cache.
+        services.AddHybridCache(options =>
+        {
+            options.DefaultEntryOptions = new HybridCacheEntryOptions
+            {
+                LocalCacheExpiration = TimeSpan.FromHours(cacheSettings.LocalCacheExpirationHours), // L1 (in-memory) Expiry
+                Expiration = TimeSpan.FromDays(cacheSettings.DistributedCacheExpirationDays),       // L2 (redis) Expiry
+            };
+            options.MaximumPayloadBytes = cacheSettings.MaxPayloadBytes;
+        });
+#pragma warning restore EXTEXP0018
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IMoviesService, MoviesService>();

--- a/MoviePicks.Api/appsettings.json
+++ b/MoviePicks.Api/appsettings.json
@@ -12,6 +12,12 @@
     "movieDatabaseSqlServer": ""
   },
 
+  "HybridCache": {
+    "LocalCacheExpirationHours": 1,
+    "DistributedCacheExpirationDays": 30,
+    "MaxPayloadBytes": 1048576
+  },
+
   "Omdb": {
     "BaseUrl": "https://www.omdbapi.com/"
   }

--- a/MoviePicks.AppHost/AppHost.cs
+++ b/MoviePicks.AppHost/AppHost.cs
@@ -1,12 +1,44 @@
+using Microsoft.Extensions.Configuration;
+using MoviePicks.AppHost;
 using MoviePicks.Contracts;
 
 var builder = DistributedApplication.CreateBuilder(args);
+
+var redisSettings = builder.Configuration.GetSection("Redis").Get<RedisSettings>() ?? new();
+
+IResourceBuilder<IResourceWithConnectionString> redis;
+
+if (redisSettings.UseCloudRedis)
+{
+    // Use an external Redis server configured in AppHost user secrets
+    // under ConnectionStrings:redis-cache as specified by BackendInfrastructureConstants.RedisResourceConnectionName.
+    // This cloud connection string path has not been tested.
+    redis = builder.AddConnectionString(BackendInfrastructureConstants.RedisResourceConnectionName);
+}
+else
+{
+    // Use local Docker Desktop containerized Redis
+    var localRedis = builder.AddRedis(BackendInfrastructureConstants.RedisResourceConnectionName)
+                            .WithRedisInsight(); // Redis Insights is a GUI for analyzing Redis data.
+
+    if (redisSettings.UsePersistentCache)
+    {
+        // Configure Redis to snapshot after at least 60 seconds have elapsed
+        // since the last save and at least one key-changing operation has occurred.
+        // Store snapshots in a named Docker volume so saved cache data survives
+        // container recreation. Unsaved changes can be lost after an abrupt shutdown.
+        localRedis.WithPersistence(interval: TimeSpan.FromMinutes(1), keysChangedThreshold: 1)
+                  .WithDataVolume(redisSettings.VolumeName);
+    }
+    redis = localRedis;
+}
 
 var backendApi = builder.AddProject<Projects.MoviePicks_Api>(
     AspireResourceName
         .ServiceDiscovery
         .Project
-        .MoviePicksApi);
+        .MoviePicksApi)
+        .WithReference(redis);
 
 // Frontend web UI project
 builder.AddProject<Projects.MoviePicks_Web>(

--- a/MoviePicks.AppHost/MoviePicks.AppHost.csproj
+++ b/MoviePicks.AppHost/MoviePicks.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,6 +7,10 @@
     <Nullable>enable</Nullable>
     <UserSecretsId>0e5be444-0eb2-409f-9f1c-fb2e11860efa</UserSecretsId>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.3" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MoviePicks.Api\MoviePicks.Api.csproj" />

--- a/MoviePicks.AppHost/RedisSettings.cs
+++ b/MoviePicks.AppHost/RedisSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace MoviePicks.AppHost;
+
+public class RedisSettings
+{
+    public bool UseCloudRedis { get; set; } = false;
+    public bool UsePersistentCache { get; set; } = true; // Scenario B
+    public string VolumeName { get; set; } = "movie-picks-redis-data";
+}

--- a/MoviePicks.AppHost/appsettings.json
+++ b/MoviePicks.AppHost/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning",
       "Aspire.Hosting.Dcp": "Warning"
     }
+  },
+  "Redis": {
+    "UseCloudRedis": false,
+    "UsePersistentCache": true,
+    "VolumeName": "movie-picks-redis-data"
   }
 }

--- a/MoviePicks.Contracts/BackendInfrastructureConstants.cs
+++ b/MoviePicks.Contracts/BackendInfrastructureConstants.cs
@@ -1,0 +1,23 @@
+﻿namespace MoviePicks.Contracts;
+
+/// <summary>
+/// Shared constants only for backend infrastructure.
+/// </summary>
+/// <remarks>
+/// The Web frontend project should not use these constants; they are backend infrastructure only.
+/// </remarks>
+public static class BackendInfrastructureConstants
+{
+    /// <summary>
+    /// Infrastructure constant shared between the Aspire MoviePicks.AppHost project and
+    /// the MoviePicks.Api service project.
+    /// </summary>
+    /// <remarks>
+    /// This constant lives in MoviePicks.Contracts rather than in MoviePicks.Api because
+    /// MoviePicks.AppHost needs them for Aspire resource wiring, and the MoviePicks.AppHost-to-MoviePicks.Api
+    /// project reference is an Aspire service-discovery reference — not a normal code-sharing reference.
+    /// MoviePicks.Contracts is the lowest-level project that both AppHost and Api can reference
+    /// without coupling the Aspire AppHost orchestrator project to the MoviePicks.Api project.
+    /// </remarks>
+    public const string RedisResourceConnectionName = "redis-cache";
+}

--- a/MoviePicks.ServiceDefaults/MoviePicks.ServiceDefaults.csproj
+++ b/MoviePicks.ServiceDefaults/MoviePicks.ServiceDefaults.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/MoviePicks.Web/MoviePicks.Web.csproj
+++ b/MoviePicks.Web/MoviePicks.Web.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
Reduce repeated OMDb requests by caching movie details in memory and Redis. Make expiration and payload limits configurable, with separate cache entries for each IMDb ID and plot size. Leave title searches uncached.

Rename the reader interface to IOmdbMoviesReader and the HTTP reader to OmdbMoviesReader. Register CachedOmdbApiMoviesReader as a wrapper around the HTTP reader so controllers and movie services receive caching through dependency injection.

Configure Aspire to run Redis locally with RedisInsight and optional snapshot persistence in a named Docker volume.

Add an option to connect to a separately hosted Redis server, such as Redis Cloud, using an AppHost connection string. Keep this option disabled by default and document that it has not been tested.

Reject unsuccessful OMDb detail responses before they reach the cache. Use a shared, case-insensitive success check for detail and search responses.

Remove unused service dependencies and unreachable code, and update Aspire and other NuGet package dependencies.